### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php" : "~7.0",
-        "illuminate/support": "^5.4",
+        "illuminate/support": "5.4.* || 5.5.*",
         "ctf0/package-changelog": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.